### PR TITLE
Use `trapezoid` instead of `trapz`, and remove scri dependency warning

### DIFF
--- a/mayawaves/coalescence.py
+++ b/mayawaves/coalescence.py
@@ -292,11 +292,6 @@ class Coalescence:
         Args:
             center_of_mass_corrected (:obj:`bool`, optional): Whether to correct for center of mass drift. Default False. If false, the frame is set back to the original, raw frame.
         """
-        import sys
-        if sys.version_info.major == 3 and sys.version_info.minor > 10:
-            warnings.warn('Python version too recent to be compatible with Scri package. Unable to change the radiation frame.')
-            raise ImportError('Unable to change the radiation frame. Python version too recent to be compatible with Scri package. If you would like the ability to move to center-of-mass corrected frame, use python <= 3.10.')
-
         from mayawaves.radiation import Frame
 
         if center_of_mass_corrected:

--- a/mayawaves/radiation.py
+++ b/mayawaves/radiation.py
@@ -1336,8 +1336,8 @@ class RadiationSphere:
         x0 = np.zeros(3)
         xt0 = np.zeros(3)
         for i in range(3):
-            x0[i] = scipy.integrate.trapz(com_maya_int[:, i], t_com_maya_int) / (tf - ti)
-            xt0[i] = scipy.integrate.trapz(com_maya_int[:, i] * t_com_maya_int, t_com_maya_int) / (tf - ti)
+            x0[i] = scipy.integrate.trapezoid(com_maya_int[:, i], t_com_maya_int) / (tf - ti)
+            xt0[i] = scipy.integrate.trapezoid(com_maya_int[:, i] * t_com_maya_int, t_com_maya_int) / (tf - ti)
 
         # calculate alpha and beta with the Newtonian approach
         self.__alpha = (4 * (tf ** 2 + tf * ti + ti * 2) * x0 - 6 * (tf + ti) * xt0) / (tf - ti) ** 2

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ romspline
 wget
 matplotlib
 mock
-numba; python_version < '3.11'
-scri; python_version < '3.11'
+numba
+scri


### PR DESCRIPTION
- [x] Use `trapezoid` instead of `trapz`, since the latter is deprecated
- [x] `scri` no longer requires `python<3.11`, same with `numba`